### PR TITLE
feat(tsconfig): add declarationMap true to tsconfig for easy debugging

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
     "jsx": "react-jsx",
     "noFallthroughCasesInSwitch": true,
     "declaration": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "declarationMap": true
   },
   "include": ["src"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
#9

if we have a declaration map, we can drill down the original definition by using VS code go to definition and makes the debugging a little easier.