### PR TITLE
fix!: updating semantic release config - test breaking change

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -14,6 +14,7 @@ const commitAnalyzerPlugin = [
       { type: 'perf', release: 'patch' },
       { type: 'docs', scope: 'README', release: 'patch' },
     ],
+    preset: 'conventionalcommits',
   },
 ]
 
@@ -40,7 +41,12 @@ module.exports = {
     // generate release notes
     '@semantic-release/release-notes-generator',
     // put generated release notes into a changelog
-    '@semantic-release/changelog',
+    [
+      '@semantic-release/changelog',
+      {
+        preset: 'conventionalcommits',
+      },
+    ],
     // publish package
     publishPackagePlugin,
     // commit changelog and version changes


### PR DESCRIPTION
Supporting `!` after `type/scope` that is used in conventional commits (https://www.conventionalcommits.org/en/v1.0.0/). 

This can be achieved by adding preset to the config: https://github.com/guardian/commercial/pull/848/files